### PR TITLE
chore: change Mythic Dungeon Tools to Manbaby Dungeon Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Yeah this is just nnogie's addon yoinked under a GPL 2 license because he's a ginoromous man baby
 
-Mythic Dungeon Tools
-------------------
-![Main Window](https://i.imgur.com/HFzS0Xl.jpg "x")
+## Manbaby Dungeon Tools
 
-Mythic Dungeon Tools is a Mythic+ Dungeon Planner AddOn which helps you perfectly plan out your strategies and pull patterns in Mythic+ Dungeons. Every NPC in every Shadowlands dungeon has been mapped out and can be viewed on an interactive map. Furthermore you have the option to select these enemies and devide the enemies you wish to defeat into pulls. While going through the dungeon and selecting more enemies the progress bar will fill up and you will know exactly which enemies to kill to reach perfect enemy forces count. When done with selecting enemies the reoute can be exported and shared via a paste string or send to party members ingame so other users of the AddOn can see what you have planned for the dungeon.
+![Main Window](https://i.imgur.com/HFzS0Xl.jpg 'x')
 
-Features
-------------------
+Manbaby Dungeon Tools is a Mythic+ Dungeon Planner AddOn which helps you perfectly plan out your strategies and pull patterns in Mythic+ Dungeons. Every NPC in every Shadowlands dungeon has been mapped out and can be viewed on an interactive map. Furthermore you have the option to select these enemies and devide the enemies you wish to defeat into pulls. While going through the dungeon and selecting more enemies the progress bar will fill up and you will know exactly which enemies to kill to reach perfect enemy forces count. When done with selecting enemies the reoute can be exported and shared via a paste string or send to party members ingame so other users of the AddOn can see what you have planned for the dungeon.
+
+## Features
+
 - Maps for all Shadowlands+BFA+Legion dungeons
 - NPC positions for all dungeons
 - Patrol paths for all patroling NPCs
@@ -20,11 +20,9 @@ Features
 - Ingame sharing functions to share routes to party members
 - Live mode for cooperative editing of routes including drawing, selecting enemies and more!
 
+## Slash Commands
 
-Slash Commands
-------------------
 - /manbabydungeontools
 - /mdt
 
-Download on curseforge: https://www.curseforge.com/wow/addons/mythic-dungeon-tools XD XD XD XD XD 
-
+Download on curseforge: https://www.curseforge.com/wow/addons/mythic-dungeon-tools XD XD XD XD XD


### PR DESCRIPTION
Some of these changes are auto-formatter changes `¯\_(ツ)_/¯`

Most importantly, this changes all the references of `Mythic Dungeon Tools` to `Manbaby Dungeon Tools`