### PR TITLE
Github action to build releases

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,62 @@
+---
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  gh_tagged_release:
+    runs-on: "ubuntu-latest"
+    env:
+      JEST_VERBOSE: ${{ secrets.JEST_VERBOSE }}
+
+    steps:
+      - name: "Check out code"
+        uses: "actions/checkout@v2"
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Get name of addon
+        id: init
+        run: |
+          addon_name=$(ls *.toc)
+          addon_name=$(basename $addon_name .toc)
+          tag_name=${addon_name}-${{steps.get_version.outputs.VERSION}}
+          echo "::set-output name=addon_name::${addon_name}"
+          echo "::set-output name=tag_name::${tag_name}"
+      - name: Make folder for zips
+        run: |
+          mkdir -p .releases/${{steps.init.outputs.addon_name}}
+          rsync -r --exclude '.*' . .releases/${{steps.init.outputs.addon_name}}
+      - name: Clear all unnecessary files
+        run: |
+          cd .releases/${{steps.init.outputs.addon_name}}
+          rm -rf $(cat ../../.releaseignore)
+      - name: Create retail zip
+        run: |
+          cd .releases
+          zip -9 -r ${{steps.get_version.outputs.VERSION}}.zip ${{steps.init.outputs.addon_name}}
+          cd ..
+      - name: Tag this version
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{steps.init.outputs.addon_name}} ${{steps.get_version.outputs.VERSION}}
+          body: ${{steps.init.outputs.addon_name}} ${{steps.get_version.outputs.VERSION}}
+          draft: false
+          prerelease: false
+      - name: Add retail zip to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: .releases/${{steps.get_version.outputs.VERSION}}.zip
+          asset_name: ${{steps.init.outputs.tag_name}}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           cd .releases/${{steps.init.outputs.addon_name}}
           rm -rf $(cat ../../.releaseignore)
+      - name: Change TOC version
+        run: |
+          cd .releases/${{steps.init.output.addon_name}}
+          sed -i 's/## Version: (.+)/## Version: ${{steps.get_version.outputs.VERSION}}/g' ManbabyDungeonTools.toc
       - name: Create retail zip
         run: |
           cd .releases

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -37,7 +37,7 @@ jobs:
           rm -rf $(cat ../../.releaseignore)
       - name: Change TOC version
         run: |
-          cd .releases/${{steps.init.output.addon_name}}
+          cd .releases/${{steps.init.outputs.addon_name}}
           sed -i 's/## Version: (.+)/## Version: ${{steps.get_version.outputs.VERSION}}/g' ManbabyDungeonTools.toc
       - name: Create retail zip
         run: |

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -18,7 +18,9 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=VERSION_NO_V::${GITHUB_REF/refs\/tags\/v/}
       - name: Get name of addon
         id: init
         run: |
@@ -38,7 +40,7 @@ jobs:
       - name: Change TOC version
         run: |
           cd .releases/${{steps.init.outputs.addon_name}}
-          sed -i 's/## Version: (.+)/## Version: ${{steps.get_version.outputs.VERSION}}/g' ManbabyDungeonTools.toc
+          sed -i 's/## Version: .*/## Version: ${{steps.get_version.outputs.VERSION_NO_V}}/g' ManbabyDungeonTools.toc
       - name: Create retail zip
         run: |
           cd .releases

--- a/.releaseignore
+++ b/.releaseignore
@@ -1,0 +1,4 @@
+.git
+.gitattributes
+.gitignore
+python


### PR DESCRIPTION
Allows us to not have to fuck around with releases!

Tagging a commit as `vX` (Where, ideally, `X` is actually `X.Y.Z` - `v1.2.3` for example) will automatically trigger a github action to copy all files to a release folder, strip what we don't want (specified in `.releaseignore`), zip the whole thing and release as a github release.

It also automatically updates TOC version, so at least in the future, we won't need to care about that.

TODO:
- Changelog