### PR TITLE
Removed space at start of ' Dungeon Tools'

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,11 +1,11 @@
 <Bindings>
-    <Binding name="MDTTOGGLE" runOnUp="false" category=" Dungeon Tools">
+    <Binding name="MDTTOGGLE" runOnUp="false" category="Dungeon Tools">
       MDT:ShowInterface()
     </Binding>
-    <Binding name="MDTNPC" runOnUp="false" category=" Dungeon Tools">
+    <Binding name="MDTNPC" runOnUp="false" category="Dungeon Tools">
         MDT:AddCloneAtCursorPosition()
     </Binding>
-    <Binding name="MDTWAYPOINT" runOnUp="false" category=" Dungeon Tools">
+    <Binding name="MDTWAYPOINT" runOnUp="false" category="Dungeon Tools">
         MDT:AddPatrolWaypointAtCursorPosition()
     </Binding>
 </Bindings>

--- a/DungeonTools.lua
+++ b/DungeonTools.lua
@@ -19,7 +19,7 @@ local db
 local icon = LibStub("LibDBIcon-1.0")
 local LDB = LibStub("LibDataBroker-1.1"):NewDataObject("DungeonTools", {
 	type = "data source",
-	text = " Dungeon Tools",
+	text = "Dungeon Tools",
 	icon = "Interface\\ICONS\\inv_relics_hourglass",
 	OnClick = function(button,buttonPressed)
 		if buttonPressed == "RightButton" then
@@ -34,7 +34,7 @@ local LDB = LibStub("LibDataBroker-1.1"):NewDataObject("DungeonTools", {
 	end,
 	OnTooltipShow = function(tooltip)
 		if not tooltip or not tooltip.AddLine then return end
-		tooltip:AddLine(mythicColor .." Dungeon Tools|r")
+		tooltip:AddLine(mythicColor .."Dungeon Tools|r")
 		tooltip:AddLine(L["Click to toggle AddOn Window"])
 		tooltip:AddLine(L["Right-click to lock Minimap Button"])
 	end,
@@ -1059,7 +1059,7 @@ function MDT:MakeTopBottomTextures(frame)
 		frame.topPanelString:SetJustifyV("CENTER")
 		--frame.topPanelString:SetWidth(600)
 		frame.topPanelString:SetHeight(20)
-		frame.topPanelString:SetText(" Dungeon Tools")
+		frame.topPanelString:SetText("Dungeon Tools")
 		frame.topPanelString:ClearAllPoints()
 		frame.topPanelString:SetPoint("CENTER", frame.topPanel, "CENTER", 10, 0)
 		frame.topPanelString:Show()
@@ -4479,7 +4479,7 @@ end
 ---Register the options of the addon to the blizzard options
 function MDT:RegisterOptions()
     MDT.blizzardOptionsMenuTable = {
-        name = " Dungeon Tools",
+        name = "Dungeon Tools",
         type = 'group',
         args = {
             --[[

--- a/DungeonTools.toc
+++ b/DungeonTools.toc
@@ -1,5 +1,5 @@
 ## Interface: 90002
-## Title:  Dungeon Tools
+## Title: Dungeon Tools
 ## Author: Nnoggie
 ## Version: 3.3.4
 ## Notes: Tool for planning and optimizing Mythic+ dungeon runs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  Dungeon Tools
+# Dungeon Tools
 
 ![Release version badge](https://img.shields.io/github/v/release/LetsTimeIt/DungeonTools?style=flat-square)
 ![Download Count](https://img.shields.io/github/downloads/LetsTimeIt/DungeonTools/total?style=flat-square)


### PR DESCRIPTION
There was an extra space in the title of the addon. " Dungeon Tools". Probably from a find and replace. I went ahead and removed it so that everything lines back up. 

![Capture](https://user-images.githubusercontent.com/7977304/103315467-447b3700-49eb-11eb-86ea-a68e580b4813.PNG)
![WoWScrnShot_122920_151805](https://user-images.githubusercontent.com/7977304/103315445-388f7500-49eb-11eb-97f5-3b92fb356374.jpg)

Has now been fixed to :
![Capture1](https://user-images.githubusercontent.com/7977304/103315505-65dc2300-49eb-11eb-8035-9d328bb14d92.PNG)
![WoWScrnShot_122920_153049](https://user-images.githubusercontent.com/7977304/103315536-7be9e380-49eb-11eb-9823-0dffa7712044.jpg)
