### PR TITLE
Plaguefall inspiring mobs were slightly wrong

### DIFF
--- a/Shadowlands/Plaguefall.lua
+++ b/Shadowlands/Plaguefall.lua
@@ -196,7 +196,6 @@ MDT.dungeonEnemies[dungeonIndex] = {
             };
             [3] = {
                 ["sublevel"] = 1;
-                ["inspiring"] = true;
                 ["x"] = 351.34414485775;
                 ["g"] = 10;
                 ["y"] = -132.87993338916;
@@ -211,6 +210,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
                 ["y"] = -127.14833985717;
                 ["x"] = 343.54124065103;
                 ["g"] = 11;
+                ["inspiring"] = true;
                 ["sublevel"] = 1;
             };
             [6] = {


### PR DESCRIPTION
One mire soldier (3 - G10) was incorrectly marked as inspiring, whilst one that was inspired (5 - G11) was not marked as such. Correcting.

We're still trying to find out where the missing % went, though.