### PR TITLE
fix: update affix week dropdown on map change

### DIFF
--- a/DungeonTools.lua
+++ b/DungeonTools.lua
@@ -2767,6 +2767,7 @@ function MDT:CreateDungeonSelectDropdown(frame)
         else
             MDT:UpdateToDungeon(key)
         end
+        frame.sidePanel.affixDropdown:SetAffixWeek(MDT:GetCurrentPreset().week or MDT:GetCurrentAffixWeek() or 1)
 	end)
 	group:AddChild(group.DungeonDropdown)
 


### PR DESCRIPTION
Resolves #79 when following the repro steps as described in the issue, as well as when using Alt+Scroll to switch between maps.