### PR TITLE
Namespacing work

### DIFF
--- a/AceGUIWidget-DungeonToolsNewPullButton.lua
+++ b/AceGUIWidget-DungeonToolsNewPullButton.lua
@@ -1,5 +1,6 @@
 local Type, Version = "MDTNewPullButton", 1
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
+local MDT = DungeonTools
 local L = MDT.L
 local width,height = 248,32
 

--- a/AceGUIWidget-DungeonToolsPullButton.lua
+++ b/AceGUIWidget-DungeonToolsPullButton.lua
@@ -1,6 +1,6 @@
 local Type, Version = "MDTPullButton", 1
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 
 

--- a/AceGUIWidget-DungeonToolsSpellButton.lua
+++ b/AceGUIWidget-DungeonToolsSpellButton.lua
@@ -1,6 +1,6 @@
 local ButtonType, ButtonVersion = "MDTSpellButton", 1
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
-
+local MDT = DungeonTools
 local width,height = 248,32
 local tinsert,SetPortraitToTexture,SetPortraitTextureFromCreatureDisplayID,GetItemQualityColor,MouseIsOver = table.insert,SetPortraitToTexture,SetPortraitTextureFromCreatureDisplayID,GetItemQualityColor,MouseIsOver
 

--- a/AceGUIWidget-DungeonToolsSpellLabel.lua
+++ b/AceGUIWidget-DungeonToolsSpellLabel.lua
@@ -1,6 +1,6 @@
 local LabelType, LabelVersion = "MDTSpellLabel", 1
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
-
+local MDT = DungeonTools
 local width,height = 248,18
 local tinsert,SetPortraitToTexture,SetPortraitTextureFromCreatureDisplayID,GetItemQualityColor,MouseIsOver = table.insert,SetPortraitToTexture,SetPortraitTextureFromCreatureDisplayID,GetItemQualityColor,MouseIsOver
 

--- a/BattleForAzeroth/AtalDazar.lua
+++ b/BattleForAzeroth/AtalDazar.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 15
 MDT.dungeonTotalCount[dungeonIndex] = {normal=198,teeming=237,teemingEnabled=true}

--- a/BattleForAzeroth/Freehold.lua
+++ b/BattleForAzeroth/Freehold.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 16
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/KingsRest.lua
+++ b/BattleForAzeroth/KingsRest.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 17
 MDT.dungeonTotalCount[dungeonIndex] = {normal=246,teeming=286,teemingEnabled=true}

--- a/BattleForAzeroth/MechagonCity.lua
+++ b/BattleForAzeroth/MechagonCity.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 26
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/MechagonIsland.lua
+++ b/BattleForAzeroth/MechagonIsland.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 25
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/ShrineoftheStorm.lua
+++ b/BattleForAzeroth/ShrineoftheStorm.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 18
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/SiegeofBoralus.lua
+++ b/BattleForAzeroth/SiegeofBoralus.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 19
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/TempleofSethraliss.lua
+++ b/BattleForAzeroth/TempleofSethraliss.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 20
 MDT.dungeonTotalCount[dungeonIndex] = {normal=220,teeming=264,teemingEnabled=true}

--- a/BattleForAzeroth/TheMotherlode.lua
+++ b/BattleForAzeroth/TheMotherlode.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 21
 MDT.dungeonTotalCount[dungeonIndex] = {normal=384,teeming=460,teemingEnabled=true}

--- a/BattleForAzeroth/TheUnderrot.lua
+++ b/BattleForAzeroth/TheUnderrot.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 22
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/TolDagor.lua
+++ b/BattleForAzeroth/TolDagor.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 23
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/WaycrestManor.lua
+++ b/BattleForAzeroth/WaycrestManor.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 24
 MDT.mapInfo[dungeonIndex] = {

--- a/BattleForAzeroth/overrides.lua
+++ b/BattleForAzeroth/overrides.lua
@@ -1,3 +1,4 @@
+local MDT = DungeonTools
 local displayIdOverrides = {
 
 }

--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,11 +1,11 @@
 <Bindings>
-    <Binding name="MDTTOGGLE" runOnUp="false" category="Dungeon Tools">
-      MDT:ShowInterface()
+    <Binding name="DungeonToolsToggle" runOnUp="false" category="Dungeon Tools">
+      DungeonTools:ShowInterface()
     </Binding>
-    <Binding name="MDTNPC" runOnUp="false" category="Dungeon Tools">
-        MDT:AddCloneAtCursorPosition()
+    <Binding name="DungeonToolsNPC" runOnUp="false" category="Dungeon Tools">
+        DungeonTools:AddCloneAtCursorPosition()
     </Binding>
-    <Binding name="MDTWAYPOINT" runOnUp="false" category="Dungeon Tools">
-        MDT:AddPatrolWaypointAtCursorPosition()
+    <Binding name="DungeonToolsWaypoint" runOnUp="false" category="Dungeon Tools">
+        DungeonTools:AddPatrolWaypointAtCursorPosition()
     </Binding>
 </Bindings>

--- a/DataCollection.lua
+++ b/DataCollection.lua
@@ -1,8 +1,8 @@
 ---Tracks spells casted by enemies and adds them to the dataset
 local db
 local f
-local MDT = MDT
-
+local MDT = DungeonTools
+local commsObject = MDT.commsObject
 MDT.DataCollection = {}
 local DC = MDT.DataCollection
 function DC:Init()
@@ -232,7 +232,7 @@ function MDT:RequestDataCollectionUpdate()
     if true then return end
     local distribution = self:IsPlayerInGroup()
     if not distribution then return end
-    MDTcommsObject:SendCommMessage(self.dataCollectionPrefixes.request, "0", distribution, nil, "ALERT")
+    commsObject:SendCommMessage(self.dataCollectionPrefixes.request, "0", distribution, nil, "ALERT")
 end
 
 ---Distribute collected data to party/raid
@@ -250,7 +250,7 @@ function DC:DistributeData()
             [2] = db.dataCollectionCC
         }
         local export = MDT:TableToString(package,false,5)
-        MDTcommsObject:SendCommMessage(MDT.dataCollectionPrefixes.distribute, export, distribution, nil, "BULK",nil,nil)
+        commsObject:SendCommMessage(MDT.dataCollectionPrefixes.distribute, export, distribution, nil, "BULK",nil,nil)
     end
 end
 

--- a/DungeonEnemies.lua
+++ b/DungeonEnemies.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local db
 local tonumber,tinsert,slen,pairs,ipairs,tostring,next,type,sformat,twipe,max,tremove,DrawLine = tonumber,table.insert,string.len,pairs,ipairs,tostring,next,type,string.format,table.wipe,math.max,table.remove,DrawLine
 local L = MDT.L
@@ -66,7 +66,7 @@ function MDT:DoFramesOverlap(frameA, frameB, offset)
 end
 
 
-MDTDungeonEnemyMixin = {};
+DungeonToolsEnemyMixin = {};
 
 local defaultSizes = {
     ["texture_Background"] = 20,
@@ -83,13 +83,13 @@ local defaultSizes = {
     ["texture_DragUp"] = 8,
 }
 
-function MDTDungeonEnemyMixin:updateSizes(scale)
+function DungeonToolsEnemyMixin:updateSizes(scale)
     for tex,size in pairs(defaultSizes) do
         self[tex]:SetSize(size*self.normalScale*scale,size*self.normalScale*scale)
     end
 end
 
-function MDTDungeonEnemyMixin:OnEnter()
+function DungeonToolsEnemyMixin:OnEnter()
     self:updateSizes(1.2)
     self:SetFrameLevel(self:GetFrameLevel()+5)
     self:DisplayPatrol(true)
@@ -131,7 +131,7 @@ function MDTDungeonEnemyMixin:OnEnter()
     end
 end
 
-function MDTDungeonEnemyMixin:OnLeave()
+function DungeonToolsEnemyMixin:OnLeave()
     self:updateSizes(1)
     self:SetFrameLevel(self:GetFrameLevel()-5)
     if db.devMode then
@@ -306,7 +306,7 @@ local function setUpMouseHandlersAwakened(self,clone,scale,riftOffsets)
     end)
 end
 
-function MDTDungeonEnemyMixin:OnClick(button, down)
+function DungeonToolsEnemyMixin:OnClick(button, down)
 
     if button == "LeftButton" then
         if IsShiftKeyDown() then
@@ -393,7 +393,7 @@ function MDT:GetPatrolBlips()
     return patrolPoints
 end
 
-function MDTDungeonEnemyMixin:DisplayPatrol(shown)
+function DungeonToolsEnemyMixin:DisplayPatrol(shown)
     local scale = MDT:GetScale()
 
     --Hide all points/line
@@ -607,7 +607,7 @@ end
 
 local emissaryIds = {[155432]=true,[155433]=true,[155434]=true}
 
-function MDTDungeonEnemyMixin:SetUp(data,clone)
+function DungeonToolsEnemyMixin:SetUp(data,clone)
     local scale = MDT:GetScale()
     self:ClearAllPoints()
     self:SetPoint("CENTER", MDT.main_frame.mapPanelTile1,"TOPLEFT",clone.x*scale,clone.y*scale)
@@ -706,7 +706,7 @@ function MDT:DungeonEnemies_UpdateEnemies()
             if clone.sublevel == currentSublevel or (not clone.sublevel) then
                 --skip rifts that were dragged to another sublevel
                 if not (data.corrupted and riftOffsets and riftOffsets[data.id] and riftOffsets[data.id].sublevel) then
-                    local blip = MDT.dungeonEnemies_framePools:Acquire("MDTDungeonEnemyTemplate")
+                    local blip = MDT.dungeonEnemies_framePools:Acquire("DungeonToolsEnemyTemplate")
                     blip:SetUp(data,clone)
                     blip.enemyIdx = enemyIdx
                     blip.cloneIdx = cloneIdx
@@ -721,7 +721,7 @@ function MDT:DungeonEnemies_UpdateEnemies()
                 for enemyIdx,data in pairs(enemies) do
                     if data.id == npcId then
                         for cloneIdx,clone in pairs(data["clones"]) do
-                            local blip = MDT.dungeonEnemies_framePools:Acquire("MDTDungeonEnemyTemplate")
+                            local blip = MDT.dungeonEnemies_framePools:Acquire("DungeonToolsEnemyTemplate")
                             blip:SetUp(data,clone)
                             blip.enemyIdx = enemyIdx
                             blip.cloneIdx = cloneIdx
@@ -736,7 +736,7 @@ end
 function MDT:DungeonEnemies_CreateFramePools()
     db = self:GetDB()
     MDT.dungeonEnemies_framePools = MDT.dungeonEnemies_framePools or CreateFramePoolCollection()
-    MDT.dungeonEnemies_framePools:CreatePool("Button", MDT.main_frame.mapPanelFrame, "MDTDungeonEnemyTemplate");
+    MDT.dungeonEnemies_framePools:CreatePool("Button", MDT.main_frame.mapPanelFrame, "DungeonToolsEnemyTemplate");
 end
 
 function MDT:FindPullOfBlip(blip)
@@ -908,6 +908,10 @@ end
 ---DungeonEnemies_GetPullColor
 ---Returns the custom color for a pull
 function MDT:DungeonEnemies_GetPullColor(pull,pulls)
+    if not preset or not preset.value or not preset.value.pulls then
+        r,g,b = MDT:HexToRGB(db.defaultColor)
+        return r,g,b
+    end
     pulls = pulls or preset.value.pulls
     local r,g,b = MDT:HexToRGB(pulls[pull]["color"])
     if not r then

--- a/DungeonEnemies.lua
+++ b/DungeonEnemies.lua
@@ -489,7 +489,8 @@ function MDT:DisplayBlipTooltip(blip, shown)
     ]]
     local occurence = (blip.data.isBoss and "") or blip.cloneIdx
 
-    local text = data.name.." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,data.creatureType).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
+    local mobName = data.name or ""
+    local text = mobName.." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,data.creatureType).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
     local count = MDT:IsCurrentPresetTeeming() and data.teemingCount or data.count
     text = text ..L["Forces"]..": ".. MDT:FormatEnemyForces(count)
     local reapingText

--- a/DungeonEnemies.xml
+++ b/DungeonEnemies.xml
@@ -94,7 +94,7 @@
                     </Anchors>
                 </Texture>
                 <Texture name="$parent_Indicator" hidden="false" parentKey="texture_Indicator" file = "Interface\AddOns\DungeonTools\Textures\UI-EncounterJournalTextures">
-                    <TexCoords left="0.85" right="0.97" top="0.43" bottom="0.4865"/>
+                    <TexCoords left="0.826" right="0.924" top="0.338" bottom="0.387"/>
                     <Color r="2.04" g="0" b="0" a="0"/>
                     <Anchors>
                         <Anchor point="CENTER"/>

--- a/DungeonEnemies.xml
+++ b/DungeonEnemies.xml
@@ -2,7 +2,7 @@
 ..\FrameXML\UI.xsd">
     <Script file="DungeonEnemies.lua"/>
 
-    <Button name="MDTDungeonEnemyTemplate" enableMouse="true" virtual="true" mixin="MDTDungeonEnemyMixin">
+    <Button name="DungeonToolsEnemyTemplate" enableMouse="true" virtual="true" mixin="DungeonToolsEnemyMixin">
 
         <Layers>
 
@@ -137,5 +137,5 @@
             <OnClick method="OnClick"/>
         </Scripts>
     </Button>
-    <Frame name="MDTAnimatedLineTemplate" virtual="true"/>
+    <Frame name="DungeonToolsAnimatedLineTemplate" virtual="true"/>
 </Ui>

--- a/DungeonTools.lua
+++ b/DungeonTools.lua
@@ -641,8 +641,35 @@ function MDT:GetDB()
 end
 
 local framesInitialized
+
+function MDT:ImportFromLegacyMDT()
+    mdtDb = LibStub("AceDB-3.0"):New("MythicDungeonToolsDB", defaultSavedVars).global
+    for dungeonIdx,presets in pairs(mdtDb.presets) do
+        if not db.presets[dungeonIdx] then
+            db.presets[dungeonIdx] = {}
+        end
+        oldPresetLen = #db.presets[dungeonIdx]
+        newPresetLen = #presets
+        -- Quick hack
+        db.presets[dungeonIdx][newPresetLen] = MDT:DeepCopy(db.presets[dungeonIdx][oldPresetLen])
+        currentIdx = oldPresetLen
+        for _,preset in pairs(presets) do
+            if preset["text"] ~= "Default" and preset["text"] ~= "<New Preset>" then
+                db.presets[dungeonIdx][currentIdx] = MDT:DeepCopy(preset)
+                db.presets[dungeonIdx][currentIdx]["text"] = preset["text"].." (Imported)";
+                currentIdx = currentIdx + 1
+            end
+        end
+    end
+    db.Imported = true
+end
 function MDT:ShowInterface(force)
     if not framesInitialized then initFrames() end
+    
+    if not db.Imported then
+        MDT:ImportFromLegacyMDT()
+    end
+
 	if self.main_frame:IsShown() and not force then
 		MDT:HideInterface()
 	else

--- a/DungeonTools.lua
+++ b/DungeonTools.lua
@@ -44,9 +44,9 @@ SLASH_DUNGEONTOOLS1 = "/mplus"
 SLASH_DUNGEONTOOLS2 = "/mdt"
 SLASH_DUNGEONTOOLS3 = "/dungeontools"
 
-BINDING_NAME_MDTTOGGLE = L["Toggle Window"]
-BINDING_NAME_MDTNPC = L["New NPC at Cursor Position"]
-BINDING_NAME_MDTWAYPOINT = L["New Patrol Waypoint at Cursor Position"]
+BINDING_NAME_DungeonToolsToggle = L["Toggle Window"]
+BINDING_NAME_DungeonToolsNPC = L["New NPC at Cursor Position"]
+BINDING_NAME_DungeonToolsWaypoint = L["New Patrol Waypoint at Cursor Position"]
 
 function SlashCmdList.DUNGEONTOOLS(cmd, editbox)
 	local rqst, arg = strsplit(' ', cmd)
@@ -149,23 +149,6 @@ do
 				icon:Show("DungeonTools")
 			end
 
-            --if db.dataCollectionActive then MDT.DataCollection:Init() end
-            --fix db corruption
-            do
-                for _,presets in pairs(db.presets) do
-                    for presetIdx,preset in pairs(presets) do
-                        if presetIdx == 1 then
-                            if preset.text ~= "Default" then
-                                preset.text = "Default"
-                                preset.value = {}
-                            end
-                        end
-                    end
-                end
-                for k,v in pairs(db.currentPreset) do
-                    if v <= 0 then db.currentPreset[k] = 1 end
-                end
-            end
             --register AddOn Options
             MDT:RegisterOptions()
             self:UnregisterEvent("ADDON_LOADED")

--- a/EnemyInfo.lua
+++ b/EnemyInfo.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local AceGUI = LibStub("AceGUI-3.0")
 local db

--- a/Legion/BlackRookHold.lua
+++ b/Legion/BlackRookHold.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 1
 local nerfMultiplier = 0.834
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = { normal=300, teeming=360, teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Black Rook Hold
 	[1] = {

--- a/Legion/CathedralOfEternalNight.lua
+++ b/Legion/CathedralOfEternalNight.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 2
 local pi = math.pi
 local nerfMultiplier = 1
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=305,teeming=335,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = { --Cathedral of Eternal Night
 	[2] = {

--- a/Legion/CourtOfStars.lua
+++ b/Legion/CourtOfStars.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 3
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=160,teeming=192,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Court of Stars
 	[1] = {

--- a/Legion/DarkheartThicket.lua
+++ b/Legion/DarkheartThicket.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 4
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=280,teeming=336,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Darkheart Thicket
 	[1] = {

--- a/Legion/EyeOfAzshara.lua
+++ b/Legion/EyeOfAzshara.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 5
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=206,teeming=242,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Eye of Azshara
 	[1] = {

--- a/Legion/HallsofValor.lua
+++ b/Legion/HallsofValor.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 6
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=126,teeming=151,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {
 	[1] = {

--- a/Legion/MawOfSouls.lua
+++ b/Legion/MawOfSouls.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 7
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=150,teeming=180,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Maw of Souls
 	[1] = {

--- a/Legion/NeltharionsLair.lua
+++ b/Legion/NeltharionsLair.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 8
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=220,teeming=264,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {
 	[1] = {

--- a/Legion/ReturntoKarazhanLower.lua
+++ b/Legion/ReturntoKarazhanLower.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 9
 local pi = math.pi
 local nerfMultiplier = 0.74 --npcs got nerfed by 26% compared against m0 values, bosses unchanged
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=420,teeming=504,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Lower Karazhan
 	[3] = {

--- a/Legion/ReturntoKarazhanUpper.lua
+++ b/Legion/ReturntoKarazhanUpper.lua
@@ -1,5 +1,6 @@
 local dungeonIndex = 10
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=169,teeming=202,teemingEnabled=true}
 local nerfMultiplier = 0.74 --npcs got nerfed by 26% compared against m0 values, bosses unchanged
 MDT.dungeonBosses[dungeonIndex] = {--Upper Karazhan

--- a/Legion/SeatoftheTriumvirate.lua
+++ b/Legion/SeatoftheTriumvirate.lua
@@ -1,4 +1,5 @@
 local dungeonIndex = 11
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=275,teeming=329,teemingEnabled=true}
 local nerfMultiplier = 1
 local pi = math.pi

--- a/Legion/TheArcway.lua
+++ b/Legion/TheArcway.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 12
 local nerfMultiplier = 1
 local pi = math.pi
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=392,teeming=466,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] ={ --The Arcway
     [1] = {

--- a/Legion/VaultoftheWardens.lua
+++ b/Legion/VaultoftheWardens.lua
@@ -1,6 +1,7 @@
 local dungeonIndex = 13
 local pi = math.pi
 local nerfMultiplier = 1
+local MDT = DungeonTools
 MDT.dungeonTotalCount[dungeonIndex] = {normal=210,teeming=252,teemingEnabled=true}
 MDT.dungeonBosses[dungeonIndex] = {--Vault of the Wardens
 	[1] = {

--- a/LiveSession.lua
+++ b/LiveSession.lua
@@ -1,6 +1,6 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
-local MDTcommsObject = MDTcommsObject
+local commsObject = MDT.commsObject
 local twipe,tinsert = table.wipe,table.insert
 
 local timer
@@ -74,7 +74,7 @@ function MDT:LiveSession_NotifyEnabled()
         local distribution = self:IsPlayerInGroup()
         if (not distribution) or (not self.liveSessionActive) then return end
         local uid = self.livePresetUID
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.enabled, uid, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.enabled, uid, distribution, nil, "ALERT")
     end
     --self:SendToGroup(self:IsPlayerInGroup(),true,self:GetCurrentLivePreset())
 end
@@ -86,7 +86,7 @@ function MDT:LiveSession_RequestSession()
     self.liveSessionRequested = true
     self.liveSessionActiveSessions = self.liveSessionActiveSessions or {}
     twipe(self.liveSessionActiveSessions)
-    MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.request, "0", distribution, nil, "ALERT")
+    commsObject:SendCommMessage(self.liveSessionPrefixes.request, "0", distribution, nil, "ALERT")
 end
 
 
@@ -129,7 +129,7 @@ end
 function MDT:LiveSession_RequestPreset(fullName)
     local distribution = self:IsPlayerInGroup()
     if (not distribution) or (not self.liveSessionActive) then return end
-    MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.reqPre, fullName, distribution,nil, "ALERT")
+    commsObject:SendCommMessage(self.liveSessionPrefixes.reqPre, fullName, distribution,nil, "ALERT")
 end
 
 ---Sends a map ping
@@ -139,7 +139,7 @@ function MDT:LiveSession_SendPing(x, y, sublevel)
         local distribution = self:IsPlayerInGroup()
         if distribution then
             local scale = self:GetScale()
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.ping, x*(1/scale)..":"..y*(1/scale)..":"..sublevel, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.ping, x*(1/scale)..":"..y*(1/scale)..":"..sublevel, distribution, nil, "ALERT")
         end
     end
 end
@@ -150,7 +150,7 @@ function MDT:LiveSession_SendObject(obj)
         local distribution = self:IsPlayerInGroup()
         if distribution then
             local export = MDT:TableToString(obj,false,5)
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.obj, export, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.obj, export, distribution, nil, "ALERT")
         end
     end
 end
@@ -160,7 +160,7 @@ function MDT:LiveSession_SendObjectOffsets(objIdx, x, y)
     if self:GetCurrentPreset().uid == self.livePresetUID then
         local distribution = self:IsPlayerInGroup()
         if distribution then
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.objOff, objIdx..":"..x..":"..y, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.objOff, objIdx..":"..x..":"..y, distribution, nil, "ALERT")
         end
     end
 end
@@ -171,7 +171,7 @@ function MDT:LiveSession_SendUpdatedObjects(changedObjects)
         local distribution = self:IsPlayerInGroup()
         if distribution then
             local export = MDT:TableToString(changedObjects,false,5)
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.objChg, export, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.objChg, export, distribution, nil, "ALERT")
         end
     end
 end
@@ -181,7 +181,7 @@ function MDT:LiveSession_SendCommand(cmd)
     if self:GetCurrentPreset().uid == self.livePresetUID then
         local distribution = self:IsPlayerInGroup()
         if distribution then
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.cmd, cmd, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.cmd, cmd, distribution, nil, "ALERT")
         end
     end
 end
@@ -192,7 +192,7 @@ function MDT:LiveSession_SendNoteCommand(cmd, noteIdx, text, y)
         local distribution = self:IsPlayerInGroup()
         if distribution then
             text = text..":"..(y or "0")
-            MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.note, cmd..":"..noteIdx..":"..text, distribution, nil, "ALERT")
+            commsObject:SendCommMessage(self.liveSessionPrefixes.note, cmd..":"..noteIdx..":"..text, distribution, nil, "ALERT")
         end
     end
 end
@@ -205,7 +205,7 @@ function MDT:LiveSession_SendPreset(preset)
         preset.mdiEnabled = db.MDI.enabled
         preset.difficulty = db.currentDifficulty
         local export = MDT:TableToString(preset,false,5)
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.preset, export, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.preset, export, distribution, nil, "ALERT")
     end
 end
 
@@ -214,7 +214,7 @@ function MDT:LiveSession_SendPulls(pulls)
     local distribution = self:IsPlayerInGroup()
     if distribution then
         local msg = MDT:TableToString(pulls,false,5)
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.pull, msg, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.pull, msg, distribution, nil, "ALERT")
     end
 end
 
@@ -222,7 +222,7 @@ end
 function MDT:LiveSession_SendAffixWeek(week)
     local distribution = self:IsPlayerInGroup()
     if distribution then
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.week, week.."", distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.week, week.."", distribution, nil, "ALERT")
     end
 end
 
@@ -232,7 +232,7 @@ function MDT:LiveSession_SendFreeholdSelector(value, week)
     if distribution then
         value = value and "T:" or "F:"
         local msg = value..week
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.free, msg, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.free, msg, distribution, nil, "ALERT")
     end
 end
 
@@ -241,7 +241,7 @@ function MDT:LiveSession_SendBoralusSelector(faction)
     local distribution = self:IsPlayerInGroup()
     if distribution then
         local msg = faction..""
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.bora, msg, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.bora, msg, distribution, nil, "ALERT")
     end
 end
 
@@ -250,7 +250,7 @@ function MDT:LiveSession_SendMDI(action, data)
     local distribution = self:IsPlayerInGroup()
     if distribution then
         local msg = action..":"..data
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.mdi, msg, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.mdi, msg, distribution, nil, "ALERT")
     end
 end
 
@@ -272,7 +272,7 @@ function MDT:LiveSession_SendCorruptedPositions(offsets)
     local distribution = self:IsPlayerInGroup()
     if distribution then
         local export = MDT:TableToString(offsets,false,5)
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.corrupted, export, distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.corrupted, export, distribution, nil, "ALERT")
     end
 end
 
@@ -281,6 +281,6 @@ function MDT:LiveSession_SendDifficulty()
     local distribution = self:IsPlayerInGroup()
     if distribution then
         local export = self:GetDB().currentDifficulty
-        MDTcommsObject:SendCommMessage(self.liveSessionPrefixes.difficulty, export.."", distribution, nil, "ALERT")
+        commsObject:SendCommMessage(self.liveSessionPrefixes.difficulty, export.."", distribution, nil, "ALERT")
     end
 end

--- a/Pointsofinterest.lua
+++ b/Pointsofinterest.lua
@@ -644,7 +644,7 @@ function MDT:DrawAllAnimatedLines()
             MDT:HideAnimatedLine(blip.animatedLine)
         elseif blip.data.corrupted and blip.selected then
             local connectedFrame
-            local _,active = MDT.poi_framePools:GetPool("DungeonToolsVignettePinTemplate"):EnumerateActive()
+            local _,active = MDT.poi_framePools:GetPool("VignettePinTemplate"):EnumerateActive()
             for poiFrame,_ in pairs(active) do
                 if poiFrame.spireIndex and poiFrame.npcId and poiFrame.npcId == blip.data.id then
                     connectedFrame = poiFrame
@@ -659,7 +659,7 @@ function MDT:DrawAllAnimatedLines()
         end
     end
     --draw lines from active spires to doors when their associated npc is dragged into other sublevel
-    local _,activeSpires = MDT.poi_framePools:GetPool("DungeonToolsVignettePinTemplate"):EnumerateActive()
+    local _,activeSpires = MDT.poi_framePools:GetPool("VignettePinTemplate"):EnumerateActive()
     for poiFrame,_ in pairs(activeSpires) do
         if poiFrame.spireIndex and poiFrame.npcId and not poiFrame.isSpire and not poiFrame.animatedLine then
             local connectedDoor = MDT:FindConnectedDoor(poiFrame.npcId,1)

--- a/Pointsofinterest.lua
+++ b/Pointsofinterest.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local db
 local tonumber,tinsert,slen,pairs,ipairs,tostring,next,type,sformat,tremove,twipe = tonumber,table.insert,string.len,pairs,ipairs,tostring,next,type,string.format,table.remove,table.wipe
@@ -11,7 +11,7 @@ function MDT:POI_CreateFramePools()
     MDT.poi_framePools:CreatePool("Button", MDT.main_frame.mapPanelFrame, "MapLinkPinTemplate")
     MDT.poi_framePools:CreatePool("Button", MDT.main_frame.mapPanelFrame, "DeathReleasePinTemplate")
     MDT.poi_framePools:CreatePool("Button", MDT.main_frame.mapPanelFrame, "VignettePinTemplate")
-    MDT.poi_framePools:CreatePool("Frame", MDT.main_frame.mapPanelFrame, "MDTAnimatedLineTemplate")
+    MDT.poi_framePools:CreatePool("Frame", MDT.main_frame.mapPanelFrame, "DungeonToolsAnimatedLineTemplate")
 end
 
 --devMode
@@ -579,7 +579,7 @@ local function animateLine(self, elapsed)
 end
 
 local function createAnimatedLine(parent)
-    local animatedLine = MDT.poi_framePools:Acquire("MDTAnimatedLineTemplate")
+    local animatedLine = MDT.poi_framePools:Acquire("DungeonToolsAnimatedLineTemplate")
     animatedLine:Show()
     animatedLine.phase = 0
     animatedLine.frames = {}
@@ -616,7 +616,7 @@ function MDT:ShowAnimatedLine(parent, frame1, frame2, sizeX, sizeY, gap, color, 
 end
 
 function MDT:KillAllAnimatedLines()
-    local linePool = self.poi_framePools:GetPool("MDTAnimatedLineTemplate")
+    local linePool = self.poi_framePools:GetPool("DungeonToolsAnimatedLineTemplate")
     local _,activeLines = linePool:EnumerateActive()
     for animatedLine,_ in pairs(activeLines) do
         animatedLine:SetScript("onUpdate",nil)
@@ -644,7 +644,7 @@ function MDT:DrawAllAnimatedLines()
             MDT:HideAnimatedLine(blip.animatedLine)
         elseif blip.data.corrupted and blip.selected then
             local connectedFrame
-            local _,active = MDT.poi_framePools:GetPool("VignettePinTemplate"):EnumerateActive()
+            local _,active = MDT.poi_framePools:GetPool("DungeonToolsVignettePinTemplate"):EnumerateActive()
             for poiFrame,_ in pairs(active) do
                 if poiFrame.spireIndex and poiFrame.npcId and poiFrame.npcId == blip.data.id then
                     connectedFrame = poiFrame
@@ -659,7 +659,7 @@ function MDT:DrawAllAnimatedLines()
         end
     end
     --draw lines from active spires to doors when their associated npc is dragged into other sublevel
-    local _,activeSpires = MDT.poi_framePools:GetPool("VignettePinTemplate"):EnumerateActive()
+    local _,activeSpires = MDT.poi_framePools:GetPool("DungeonToolsVignettePinTemplate"):EnumerateActive()
     for poiFrame,_ in pairs(activeSpires) do
         if poiFrame.spireIndex and poiFrame.npcId and not poiFrame.isSpire and not poiFrame.animatedLine then
             local connectedDoor = MDT:FindConnectedDoor(poiFrame.npcId,1)

--- a/Shadowlands/DeOtherSide.lua
+++ b/Shadowlands/DeOtherSide.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 29
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/HallsOfAtonement.lua
+++ b/Shadowlands/HallsOfAtonement.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 30
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/MistsOfTirnaScithe.lua
+++ b/Shadowlands/MistsOfTirnaScithe.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 31
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/Plaguefall.lua
+++ b/Shadowlands/Plaguefall.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 32
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/SanguineDepths.lua
+++ b/Shadowlands/SanguineDepths.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 33
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/SpiresOfAscension.lua
+++ b/Shadowlands/SpiresOfAscension.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 34
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/TheNecroticWake.lua
+++ b/Shadowlands/TheNecroticWake.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 35
 MDT.mapInfo[dungeonIndex] = {

--- a/Shadowlands/TheaterOfPain.lua
+++ b/Shadowlands/TheaterOfPain.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local dungeonIndex = 36
 MDT.mapInfo[dungeonIndex] = {

--- a/Transmission.lua
+++ b/Transmission.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local Compresser = LibStub:GetLibrary("LibCompress")
 local Encoder = Compresser:GetAddonEncodeTable()
@@ -15,7 +15,8 @@ local configForDeflate = {
     [8]= {level = 8},
     [9]= {level = 9},
 }
-MDTcommsObject = LibStub("AceAddon-3.0"):NewAddon("MDTCommsObject","AceComm-3.0","AceSerializer-3.0")
+MDT.commsObject = LibStub("AceAddon-3.0"):NewAddon("DungeonToolsCommsObject","AceComm-3.0","AceSerializer-3.0")
+local commsObject = MDT.commsObject
 
 -- Lua APIs
 local tostring, string_char, strsplit,tremove,tinsert = tostring, string.char, strsplit,table.remove,table.insert
@@ -182,7 +183,7 @@ MDT.dataCollectionPrefixes = {
     ["distribute"] = "MDTDataDist",
 }
 
-function MDTcommsObject:OnEnable()
+function commsObject:OnEnable()
     self:RegisterComm(presetCommPrefix)
     for _,prefix in pairs(MDT.liveSessionPrefixes) do
         self:RegisterComm(prefix)
@@ -230,7 +231,7 @@ hooksecurefunc("SetItemRef", function(link, text)
     end
 end)
 
-function MDTcommsObject:OnCommReceived(prefix, message, distribution, sender)
+function commsObject:OnCommReceived(prefix, message, distribution, sender)
     --[[
         Sender has no realm name attached when sender is from the same realm as the player
         UnitFullName("Nnoggie") returns no realm while UnitFullName("player") does
@@ -668,7 +669,7 @@ function MDT:SendToGroup(distribution,silent,preset)
     preset.mdiEnabled = db.MDI.enabled
     preset.difficulty = db.currentDifficulty
     local export = MDT:TableToString(preset,false,5)
-    MDTcommsObject:SendCommMessage("MDTPreset", export, distribution, nil, "BULK",displaySendingProgress,{distribution,preset,silent})
+    commsObject:SendCommMessage("MDTPreset", export, distribution, nil, "BULK",displaySendingProgress,{distribution,preset,silent})
 end
 
 ---GetPresetSize

--- a/devpanel.lua
+++ b/devpanel.lua
@@ -1,5 +1,5 @@
 local AceGUI = LibStub("AceGUI-3.0")
-local MDT = MDT
+local MDT = DungeonTools
 local db
 local tonumber,tinsert,slen,pairs,ipairs,tostring,next,type,sformat = tonumber,table.insert,string.len,pairs,ipairs,tostring,next,type,string.format
 local UnitName,UnitGUID,UnitCreatureType,UnitHealthMax,UnitLevel = UnitName,UnitGUID,UnitCreatureType,UnitHealthMax,UnitLevel

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,17 @@
 local AddonName, MDT = ...
 _G["DungeonTools"] = MDT
+local _L = {}
 MDT.L = {}
+local i18nMetaTable = {
+    __index = function(t, k)
+        if _L[k] == nil then
+            return k
+        else
+            return _L[k]
+        end
+    end,
+    __newindex = function(t, k, v)
+        _L[k] = v
+    end
+}
+setmetatable(MDT.L, i18nMetaTable)

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,3 @@
 local AddonName, MDT = ...
-_G["MDT"] = MDT
+_G["DungeonTools"] = MDT
 MDT.L = {}

--- a/toolbar.lua
+++ b/toolbar.lua
@@ -1,4 +1,4 @@
-local MDT = MDT
+local MDT = DungeonTools
 local L = MDT.L
 local sizex,sizey = 350,33
 local AceGUI = LibStub("AceGUI-3.0")


### PR DESCRIPTION
feat: Inspiring mobs are now _much_ more noticeable
feat: Addon now has its own namespace (`DungeonTools`). There is still one clash, but it is on the MDT side, so there's not much we can do on that.
fix: if a mob does not have an i18n entry, or if the i18n stuff fails, we fall back to the literal key provided
fix: default routes no longer get wiped