### PR TITLE
Adding a fallback for weakaura compatibility

### DIFF
--- a/DungeonTools.lua
+++ b/DungeonTools.lua
@@ -187,6 +187,9 @@ do
             C_MythicPlus.RequestCurrentAffixes()
             C_MythicPlus.RequestMapInfo()
             C_MythicPlus.RequestRewards()
+            if not MDT then
+                MDT = DungeonTools
+            end
         end)
         self:UnregisterEvent("PLAYER_ENTERING_WORLD")
     end


### PR DESCRIPTION
fix: if MDT does not exist 1s after entering the world, we assume we are the only addon for it and set ourselves in the global namespace there as an alias. This is to fix weakaura compatibility